### PR TITLE
Fix 141. Add 'exact' to route paths. narek

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -50,32 +50,35 @@ class App extends Component {
         <NavigationBar isAuthenticated={isAuthenticated} logoutHandler={() => { this.handleLogout(); }} />
         <Switch>
           <Route exact path="/" component={Home} />
-          <Route path="/about" component={About} />
-          <Route path="/events" component={Events} />
-          <Route path="/restaurants/:id/new-order" component={NewOrder} />
+          <Route exact path="/about" component={About} />
+          <Route exact path="/events" component={Events} />
+          <Route exact path="/restaurants/:id/new-order" component={NewOrder} />
           <Route
+            exact
             path="/restaurants/:id"
             render={(routeProps) => {
               return <Restaurant isAuthenticated={isAuthenticated} {...routeProps} />;
             }}
           />
-          <Route path="/restaurants" component={RestaurantList} />
+          <Route exact path="/restaurants" component={RestaurantList} />
           <Route
+            exact
             path="/login"
             render={(routeProps) => {
               return <Login loginHandler={() => { this.handleLogin(); }} {...routeProps} />;
             }}
           />
           <Route
+            exact
             path="/registration"
             render={(routeProps) => {
               return <Registration loginHandler={() => { this.handleLogin(); }} {...routeProps} />;
             }}
           />
-          <Route path="/map" component={Map} />
-          <Route path="/contact" component={Contact} />
-          <Route path="/profile" component={Profile} />
-          <Route path="" component={NoMatch} />
+          <Route exact path="/map" component={Map} />
+          <Route exact path="/contact" component={Contact} />
+          <Route exact path="/profile/info" component={Profile} />
+          <Route component={NoMatch} />
         </Switch>
         <FooterBar />
       </Router>


### PR DESCRIPTION
Our app routing works not fine. This is about configuring its routing, I think. See **[this](https://stackoverflow.com/a/36623117/13334444)** in **Server-side vs Client-side** section.

That's why when we reload our page on staging server, we get an error.

Now I just added 'exact' keyword to our routes, you can see it in 'Files changed' as well. This helps to see 404 page if we try to move .../about/1 page, for example. But, when we go to .../restaurants/2a, we still don't reach 404 page. Also my current code breaks 'Profile' page navigation.

If we configure all our routings in simple way, it will definitely work. But, I think there may be a special way to reach this configuration.

Unfortunately, today's my stackoverflow and youtube experience doesn't let me to find solution. I mean, this question needs to be investigated with full understanding how react routing works itself and with server side.

So, may be someone already has such experience? All in all, our issue on staging server is explained **[here](https://stackoverflow.com/a/57066837/13334444)** as well.