### PR TITLE
Fix 176. Role absense for seed users. narek

### DIFF
--- a/server/src/main/java/com/lunchtime/seed/DatabaseSeed.java
+++ b/server/src/main/java/com/lunchtime/seed/DatabaseSeed.java
@@ -229,6 +229,7 @@ public class DatabaseSeed {
         person.setPassword(
             bcryptPasswordEncoder.encode(userName[i].concat("password").toLowerCase()));
         person.setPhoneNumber("+38050123456".concat(String.valueOf(i)));
+        person.setRoleId(1L);
         return person;
     }
 


### PR DESCRIPTION
When developer wants to test functionality, the absense of users role by default gives useless errors in console when 'person is being mapped'. So I decided to fix this so that we have no more exceptions when testing our application in local environment.